### PR TITLE
Provide a variable for default header args

### DIFF
--- a/ob-translate.el
+++ b/ob-translate.el
@@ -19,6 +19,11 @@
 (require 'ob)
 (require 'google-translate)
 
+(defvar org-babel-default-header-args:translate '((:results . "silent raw")
+                                                  (:exports . "results")
+                                                  (:eval . "no-export"))
+  "Default arguments for evaluating a translate source block.")
+
 (defgroup ob-translate nil
   "Translate org-mode blocks."
   :group 'org)


### PR DESCRIPTION
It is an org-babel convention to provide a variable for default header args so that people don't have to set the headers args manually every time.

This is a friendly ping @krisajenkins 