### PR TITLE
Support display long lines with Org example block instead of table

### DIFF
--- a/README.org
+++ b/README.org
@@ -25,6 +25,37 @@ This is a test.
 | ja | これはテストです。  |
 #+END_EXAMPLE
 
+When the text is long lines, will show result in example block:
+
+#+begin_src translate :src en :dest de,fr,ar,ja
+When you're a kid, you can smile a lot, but when you grow, when you know a lot,
+you find that world is just mess.
+#+end_src
+
+#+RESULTS[(2020-06-01 14:14:03) bc13a0207523f2b0cbe83bc63551b5a11d0300ae]:
+#+begin_example
+language: [de]
+
+Wenn Sie ein Kind sind, können Sie viel lächeln, aber wenn Sie wachsen, wenn Sie
+viel wissen, finden Sie, dass Welt nur Chaos.
+
+language: [fr]
+
+Quand vous êtes un enfant, vous pouvez sourire beaucoup, mais quand tu seras
+grand, quand vous savez beaucoup, vous trouverez ce monde est juste gâchis.
+
+language: [ar]
+
+عندما كنت طفلا، يمكن أن تبتسم كثيرا، ولكن عندما تكبر، وعندما تعرف الكثير، تجد أن
+العالم هو الفوضى عادل.
+
+language: [ja]
+
+あなたは子供ができたら、あなたは多くのことを知っているとき、あなたは世界はただ混
+乱であることがわかり、あなたは多くのことを笑顔することができますが、大きくなった
+ら。
+#+end_example
+
 ** Installation
 
 If you're hooked up to [[http://melpa.milkbox.net/][MELPA]]:

--- a/ob-translate.el
+++ b/ob-translate.el
@@ -36,41 +36,40 @@
 (defun ob-translate:google-translate (src dest text)
   "Translate TEXT from the SRC langauge to the DEST language."
   (let* ((text-stripped (replace-regexp-in-string "[[:space:]\n\r]+" " " text))
-		 (json (json-read-from-string
-				(google-translate--insert-nulls
-				 ;; Google Translate won't let us make a request unless we
-				 ;; send a "User-Agent" header it recognizes.
-				 ;; "Mozilla/5.0" seems to work.
-				 (let ((url-request-extra-headers
-						'(("User-Agent" . "Mozilla/5.0"))))
-				   (google-translate--request src dest text-stripped))
-                 )))
+         (json (json-read-from-string
+                (google-translate--insert-nulls
+                 ;; Google Translate won't let us make a request unless we
+                 ;; send a "User-Agent" header it recognizes.
+                 ;; "Mozilla/5.0" seems to work.
+                 (let ((url-request-extra-headers
+                        '(("User-Agent" . "Mozilla/5.0"))))
+                   (google-translate--request src dest text-stripped)))))
          (text-phonetic (google-translate-json-text-phonetic json))
-		 (translation (google-translate-json-translation json))
+         (translation (google-translate-json-translation json))
          (translation-phonetic (google-translate-json-translation-phonetic json))
-		 (dict (google-translate-json-detailed-definition json)))
-	translation))
+         (dict (google-translate-json-detailed-definition json)))
+    translation))
 
 ;;;###autoload
 (defun org-babel-execute:translate (body params)
   "org-babel translation hook."
   (let ((src (or (cdr (assoc :src params))
-				 ob-translate:default-src))
-		(dest (or (cdr (assoc :dest params))
-				  ob-translate:default-dest))
-		(text (or (cddr (assoc :var params))
-				  body
-				  "")))
-	(if (string-match "," dest)
-		(mapcar (lambda (subdest)
-				  (list subdest
-						(ob-translate:google-translate src subdest text)))
-				(split-string dest ","))
-	  (ob-translate:google-translate src dest text))))
+                 ob-translate:default-src))
+        (dest (or (cdr (assoc :dest params))
+                  ob-translate:default-dest))
+        (text (or (cddr (assoc :var params))
+                  body
+                  "")))
+    (if (string-match "," dest)
+        (mapcar (lambda (subdest)
+                  (list subdest
+                        (ob-translate:google-translate src subdest text)))
+                (split-string dest ","))
+      (ob-translate:google-translate src dest text))))
 
 ;;;###autoload
 (eval-after-load "org"
- '(add-to-list 'org-src-lang-modes '("translate" . text)))
+  '(add-to-list 'org-src-lang-modes '("translate" . text)))
 
 (provide 'ob-translate)
 

--- a/ob-translate.el
+++ b/ob-translate.el
@@ -61,10 +61,24 @@
                   body
                   "")))
     (if (string-match "," dest)
-        (mapcar (lambda (subdest)
-                  (list subdest
-                        (ob-translate:google-translate src subdest text)))
-                (split-string dest ","))
+        (if (> (length text) 80)
+            ;; for long text, we use Org example block.
+            (with-temp-buffer
+              (insert (mapconcat
+                       (lambda (subdest)
+                         (concat (format "language: [%s]" subdest) "\n\n"
+                                 (ob-translate:google-translate src subdest text)
+                                 "\n"))
+                       (split-string dest ",")
+                       "\n"))
+              ;; hard wrap long lines
+              (fill-region (point-min) (point-max))
+              (buffer-substring-no-properties (point-min) (point-max)))
+          ;; Org will show "list" structure as Org table.
+          (mapcar (lambda (subdest)
+                    (list subdest
+                          (ob-translate:google-translate src subdest text)))
+                  (split-string dest ",")))
       (ob-translate:google-translate src dest text))))
 
 ;;;###autoload


### PR DESCRIPTION
It will look like this:

![image](https://user-images.githubusercontent.com/378699/83383112-0a2ac680-a417-11ea-82eb-0443c812e8c4.png)
